### PR TITLE
Fixes the inventory directory forced concatenation

### DIFF
--- a/import_runtime_template_file/tasks/main.yml
+++ b/import_runtime_template_file/tasks/main.yml
@@ -29,7 +29,7 @@
     isamapi:
       name: "{{ item.name }}"
       path: "{{ item.path }}"
-      filename: "{{ inventory_dir }}/{{ item.filename }}"
+      filename: "{{ item.filename }}"
   with_items: "{{ runtime_templates }}"
   when: item.type == "file"
   notify: Commit Changes

--- a/import_runtime_template_file/tasks/main.yml
+++ b/import_runtime_template_file/tasks/main.yml
@@ -1,12 +1,16 @@
 # main task to import template files
 #   Example:
 #     runtime_templates:
+#       - type: dir
+#         path: C/authsvc/api
 #       - type: file
-#         filename: uploads/template_files/s.json
-#         id: C/authsvc/api/success_response.json
+#         path: C/authsvc/api
+#         filename: uploads/template_files/s
+#         name: success_response.json
 #       - type: file
-#         filename: uploads/template_files/s.html
-#         id: C/authsvc/api/success_response.html
+#         path: C/authsvc/api
+#         filename: uploads/template_files/s
+#         name: success_response.html
 ---
 - name: Import template files
   isam:
@@ -23,8 +27,9 @@
     force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.aac.runtime_template.file.import_file
     isamapi:
-      id: "{{ item.id }}"
-      filename: "{{ item.filename }}"
+      name: "{{ item.name }}"
+      path: "{{ item.path }}"
+      filename: "{{ inventory_dir }}/{{ item.filename }}"
   with_items: "{{ runtime_templates }}"
   when: item.type == "file"
   notify: Commit Changes


### PR DESCRIPTION
To be able to upload template files from directories different from the inventory directory we just need to give the full path of the file location. It will no longer be relative to the inventory directory.