### PR TITLE
Replaced handler Commit Changes by Await LMI in install_fixpack role

### DIFF
--- a/install_fixpack/tasks/main.yml
+++ b/install_fixpack/tasks/main.yml
@@ -24,7 +24,7 @@
       file: "{{ install_fixpack_file }}"
   when: install_fixpack_file is defined
   notify:
-    - Commit Changes
+    - Await Appliance LMI Response
 
 # Commit activation of module before doing anything else
 - meta: flush_handlers


### PR DESCRIPTION
**Problem description :** When updating ISAM firmware, latest fixpacks are also installed. But multiple fixpacks installation eventually fail while commiting changes right after the installation task. It seems like the role needs to wait for a process to restart before commiting (LMI most likely).

**Error output :** ([see attached file for full trace output: playbook_output_trace.log](https://github.com/kalemontes/isam-ansible-roles/files/4092020/playbook_output_trace.log)

`[CRITICAL] [ibmsecurity.appliance.ibmappliance] [_process_connection_error():98] Failed to connect to server.",
    "msg": "('HTTP Return code: 502', 'Failed to connect to server')",
    "name": "ibmsecurity.isam.appliance.commit"`

**Suggested solution :**  Replace `Commit Changes` by `Await Appliance LMI Response` in `Install Fixpack` task

**Note :** In this case, handler `Commit Changes` seems to be useless, all changes (Firmware and Fixpacks updates) are applied.